### PR TITLE
Ensuring width option is working on all browsers

### DIFF
--- a/src/jquery.m.toast.js
+++ b/src/jquery.m.toast.js
@@ -33,7 +33,7 @@
         var span = "<span>" + message + "</span>";
         var item = $('<li></li>').hide();
         if(options.width > 0) {
-            span = "<span style='width: " + options.width + "'>" + message + "</span>";
+            span = "<span style='width: " + options.width + "px'>" + message + "</span>";
         }
         if(options.align == 'top') {
             item.html(span).prependTo(container);


### PR DESCRIPTION
Some Browser will not understand if the Unit is not given modified:
span = "<span style='width: " + options.width + "'>" + message + "</span>";
to:
span = "<span style='width: " + options.width + "px'>" + message + "</span>";